### PR TITLE
Replaces UnicodeUtils.display_width with Unicode::DisplayWidth.of

### DIFF
--- a/lib/verse.rb
+++ b/lib/verse.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-require 'unicode_utils/display_width'
+require 'unicode/display_width'
 require 'unicode_utils/each_grapheme'
 
 require 'verse/alignment'

--- a/lib/verse/alignment.rb
+++ b/lib/verse/alignment.rb
@@ -137,7 +137,7 @@ module Verse
 
     # @api private
     def actual_width(text)
-      UnicodeUtils.display_width(@sanitizer.sanitize(text))
+      Unicode::DisplayWidth.of(@sanitizer.sanitize(text))
     end
 
     attr_reader :text

--- a/lib/verse/padding.rb
+++ b/lib/verse/padding.rb
@@ -89,7 +89,7 @@ module Verse
     end
 
     def display_width(string)
-      UnicodeUtils.display_width(@sanitizer.sanitize(string))
+      Unicode::DisplayWidth.of(@sanitizer.sanitize(string))
     end
   end # Padding
 end # Verse

--- a/lib/verse/truncation.rb
+++ b/lib/verse/truncation.rb
@@ -112,7 +112,7 @@ module Verse
 
     # @api private
     def display_width(string)
-      UnicodeUtils.display_width(@sanitizer.sanitize(string))
+      Unicode::DisplayWidth.of(@sanitizer.sanitize(string))
     end
   end # Truncation
 end # Verse

--- a/lib/verse/wrapping.rb
+++ b/lib/verse/wrapping.rb
@@ -177,7 +177,7 @@ module Verse
     #
     # @api private
     def display_width(string)
-      UnicodeUtils.display_width(@sanitizer.sanitize(string))
+      Unicode::DisplayWidth.of(@sanitizer.sanitize(string))
     end
   end # Wrapping
 end # Verse

--- a/verse.gemspec
+++ b/verse.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'unicode_utils',     '~> 1.4.0'
+  spec.add_dependency 'unicode_utils',        '~> 1.4.0'
+  spec.add_dependency 'unicode-display_width','~> 1.1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
 end


### PR DESCRIPTION
This is a performance improvement to support the tty-table project.
Currently the tty-table gem loads very slowly, which means it can't
really be used for command line applications. One major source of
the slowness is loading the "unicode_utils/display_width" file.

To speed it up, I've replaced `UnicodeUtils.display_width` with
`Unicode::DisplayWidth.of`, which loads much more quickly.
